### PR TITLE
Public/anon submodule update fix, updated config script, and updated readme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 	url = https://github.com/mileszs/ack.vim.git
 [submodule ".vim/bundle/nerdtree"]
 	path = .vim/bundle/nerdtree
-	url = https://github.com/scrooloose/nerdtree.git.git
+	url = https://github.com/scrooloose/nerdtree.git
 [submodule ".vim/bundle/vim-colors-xoria256"]
 	path = .vim/bundle/vim-colors-xoria256
 	url = https://github.com/vim-scripts/xoria256.vim.git
@@ -45,13 +45,13 @@
 	url = https://github.com/mattn/emmet-vim.git
 [submodule ".vim/bundle/tlib_vim"]
 	path = .vim/bundle/tlib_vim
-	url = https://github.com/tomtom/tlib_vim.git.git
+	url = https://github.com/tomtom/tlib_vim.git
 [submodule ".vim/bundle/mw-utils"]
 	path = .vim/bundle/mw-utils
-	url = https://github.com/MarcWeber/vim-addon-mw-utils.git.git
+	url = https://github.com/MarcWeber/vim-addon-mw-utils.git
 [submodule ".vim/bundle/vim-snipmate"]
 	path = .vim/bundle/vim-snipmate
-	url = https://github.com/garbas/vim-snipmate.git.git
+	url = https://github.com/garbas/vim-snipmate.git
 [submodule ".vim/bundle/snipmate-nodejs"]
 	path = .vim/bundle/snipmate-nodejs
 	url = https://github.com/jamescarr/snipmate-nodejs.git
@@ -102,7 +102,7 @@
 	url = https://github.com/cakebaker/scss-syntax.vim.git
 [submodule ".vim/bundle/vim-markdown"]
 	path = .vim/bundle/vim-markdown
-	url = https://github.com/plasticboy/vim-markdown.git.git
+	url = https://github.com/plasticboy/vim-markdown.git
 [submodule ".vim/bundle/vim-closetag"]
 	path = .vim/bundle/vim-closetag
 	url = https://github.com/docunext/closetag.vim.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,126 +1,126 @@
 [submodule ".vim/bundle/vim-jade"]
 	path = .vim/bundle/vim-jade
-	url = git://github.com/digitaltoad/vim-jade.git
+	url = https://github.com/digitaltoad/vim-jade.git
 [submodule ".vim/bundle/mustache.vim"]
 	path = .vim/bundle/mustache.vim
-	url = git@github.com:juvenn/mustache.vim.git
+	url = https://github.com/juvenn/mustache.vim.git
 [submodule ".vim/bundle/vim-coffee-script"]
 	path = .vim/bundle/vim-coffee-script
-	url = git@github.com:kchmck/vim-coffee-script.git
+	url = https://github.com/kchmck/vim-coffee-script.git
 [submodule ".vim/bundle/vim-pathogen"]
 	path = .vim/bundle/vim-pathogen
-	url = git@github.com:tpope/vim-pathogen.git
+	url = https://github.com/tpope/vim-pathogen.git
 [submodule ".vim/bundle/vim-stylus"]
 	path = .vim/bundle/vim-stylus
-	url = git://github.com/wavded/vim-stylus.git
+	url = https://github.com/wavded/vim-stylus.git
 [submodule ".vim/bundle/vim-less"]
 	path = .vim/bundle/vim-less
-	url = git@github.com:groenewege/vim-less.git
+	url = https://github.com/groenewege/vim-less.git
 [submodule ".vim/bundle/vim-haml"]
 	path = .vim/bundle/vim-haml
-	url = git@github.com:tpope/vim-haml.git
+	url = https://github.com/tpope/vim-haml.git
 [submodule ".vim/bundle/vim-javascript"]
 	path = .vim/bundle/vim-javascript
-	url = git@github.com:pangloss/vim-javascript.git
+	url = https://github.com/pangloss/vim-javascript.git
 [submodule ".vim/bundle/vim-json"]
 	path = .vim/bundle/vim-json
-	url = git@github.com:elzr/vim-json.git
+	url = https://github.com/elzr/vim-json.git
 [submodule ".vim/bundle/syntastic"]
 	path = .vim/bundle/syntastic
-	url = git@github.com:scrooloose/syntastic.git
+	url = https://github.com/scrooloose/syntastic.git
 [submodule ".vim/bundle/vim-colors-solarized"]
 	path = .vim/bundle/vim-colors-solarized
-	url = git://github.com/altercation/vim-colors-solarized.git
+	url = https://github.com/altercation/vim-colors-solarized.git
 [submodule ".vim/bundle/ack.vim"]
 	path = .vim/bundle/ack.vim
-	url = git@github.com:mileszs/ack.vim.git
+	url = https://github.com/mileszs/ack.vim.git
 [submodule ".vim/bundle/nerdtree"]
 	path = .vim/bundle/nerdtree
-	url = https://github.com/scrooloose/nerdtree.git
+	url = https://github.com/scrooloose/nerdtree.git.git
 [submodule ".vim/bundle/vim-colors-xoria256"]
 	path = .vim/bundle/vim-colors-xoria256
-	url = git@github.com:vim-scripts/xoria256.vim.git
+	url = https://github.com/vim-scripts/xoria256.vim.git
 [submodule ".vim/bundle/emmet-vim"]
 	path = .vim/bundle/emmet-vim
-	url = git@github.com:mattn/emmet-vim.git
+	url = https://github.com/mattn/emmet-vim.git
 [submodule ".vim/bundle/tlib_vim"]
 	path = .vim/bundle/tlib_vim
-	url = https://github.com/tomtom/tlib_vim.git
+	url = https://github.com/tomtom/tlib_vim.git.git
 [submodule ".vim/bundle/mw-utils"]
 	path = .vim/bundle/mw-utils
-	url = https://github.com/MarcWeber/vim-addon-mw-utils.git
+	url = https://github.com/MarcWeber/vim-addon-mw-utils.git.git
 [submodule ".vim/bundle/vim-snipmate"]
 	path = .vim/bundle/vim-snipmate
-	url = https://github.com/garbas/vim-snipmate.git
+	url = https://github.com/garbas/vim-snipmate.git.git
 [submodule ".vim/bundle/snipmate-nodejs"]
 	path = .vim/bundle/snipmate-nodejs
-	url = git@github.com:jamescarr/snipmate-nodejs.git
+	url = https://github.com/jamescarr/snipmate-nodejs.git
 [submodule ".vim/bundle/vim-colors-zenburn"]
 	path = .vim/bundle/vim-colors-zenburn
-	url = git@github.com:jnurmine/Zenburn.git
+	url = https://github.com/jnurmine/Zenburn.git
 [submodule ".vim/bundle/vim-colors-twilighted"]
 	path = .vim/bundle/vim-colors-twilighted
-	url = git@github.com:brentlintner/twilighted.vim.git
+	url = https://github.com/brentlintner/twilighted.vim.git
 [submodule ".vim/bundle/vim-colors"]
 	path = .vim/bundle/vim-colors
-	url = git@github.com:spf13/vim-colors.git
+	url = https://github.com/spf13/vim-colors.git
 [submodule ".vim/bundle/vim-better-whitespace"]
 	path = .vim/bundle/vim-better-whitespace
-	url = git@github.com:ntpeters/vim-better-whitespace.git
+	url = https://github.com/ntpeters/vim-better-whitespace.git
 [submodule ".vim/bundle/vim-surround"]
 	path = .vim/bundle/vim-surround
-	url = git@github.com:tpope/vim-surround.git
+	url = https://github.com/tpope/vim-surround.git
 [submodule ".vim/bundle/nerdcommenter"]
 	path = .vim/bundle/nerdcommenter
-	url = git@github.com:scrooloose/nerdcommenter.git
+	url = https://github.com/scrooloose/nerdcommenter.git
 [submodule ".vim/bundle/ctrlp.vim"]
 	path = .vim/bundle/ctrlp.vim
-	url = git@github.com:kien/ctrlp.vim.git
+	url = https://github.com/kien/ctrlp.vim.git
 # [submodule ".vim/bundle/vim2hs"]
 # 	path = .vim/bundle/vim2hs
-# 	url = git@github.com:dag/vim2hs.git
+# 	url = https://github.com/dag/vim2hs.git
 [submodule ".vim/bundle/vim-golang"]
 	path = .vim/bundle/vim-golang
-	url = git@github.com:jnwhiteh/vim-golang.git
+	url = https://github.com/jnwhiteh/vim-golang.git
 # [submodule ".vim/bundle/vim-scala"]
 # 	path = .vim/bundle/vim-scala
-# 	url = git@github.com:derekwyatt/vim-scala.git
+# 	url = https://github.com/derekwyatt/vim-scala.git
 [submodule ".vim/bundle/vim-rdoc"]
 	path = .vim/bundle/vim-rdoc
-	url = git@github.com:depuracao/vim-rdoc.git
+	url = https://github.com/depuracao/vim-rdoc.git
 [submodule ".vim/bundle/vim-slim"]
 	path = .vim/bundle/vim-slim
-	url = git@github.com:slim-template/vim-slim.git
+	url = https://github.com/slim-template/vim-slim.git
 [submodule ".vim/bundle/vim-ruby"]
 	path = .vim/bundle/vim-ruby
-	url = git@github.com:vim-ruby/vim-ruby.git
+	url = https://github.com/vim-ruby/vim-ruby.git
 [submodule ".vim/bundle/vim-rails"]
 	path = .vim/bundle/vim-rails
-	url = git@github.com:tpope/vim-rails.git
+	url = https://github.com/tpope/vim-rails.git
 [submodule ".vim/bundle/scss-syntax.vim"]
 	path = .vim/bundle/scss-syntax.vim
-	url = git@github.com:cakebaker/scss-syntax.vim.git
+	url = https://github.com/cakebaker/scss-syntax.vim.git
 [submodule ".vim/bundle/vim-markdown"]
 	path = .vim/bundle/vim-markdown
-	url = https://github.com/plasticboy/vim-markdown.git
+	url = https://github.com/plasticboy/vim-markdown.git.git
 [submodule ".vim/bundle/vim-closetag"]
 	path = .vim/bundle/vim-closetag
-	url = git@github.com:docunext/closetag.vim.git
+	url = https://github.com/docunext/closetag.vim.git
 [submodule ".vim/bundle/vim-typescript"]
 	path = .vim/bundle/vim-typescript
-	url = git@github.com:leafgarland/typescript-vim.git
+	url = https://github.com/leafgarland/typescript-vim.git
 [submodule ".vim/bundle/gist-vim"]
 	path = .vim/bundle/gist-vim
-	url = git@github.com:mattn/gist-vim.git
+	url = https://github.com/mattn/gist-vim.git
 [submodule ".vim/bundle/webapi-vim"]
 	path = .vim/bundle/webapi-vim
-	url = git@github.com:mattn/webapi-vim.git
+	url = https://github.com/mattn/webapi-vim.git
 [submodule ".vim/bundle/vim-spacebars"]
 	path = .vim/bundle/vim-spacebars
-	url = git://github.com/Slava/vim-spacebars.git
+	url = https://github.com/Slava/vim-spacebars.git
 [submodule ".vim/bundle/tcomment-vim"]
 	path = .vim/bundle/tcomment-vim
-	url = git@github.com:tomtom/tcomment_vim.git
+	url = https://github.com/tomtom/tcomment_vim.git
 # [submodule ".vim/bundle/jquery"]
 # 	path = .vim/bundle/jquery
-# 	url = git@github.com:nono/jquery.vim.git
+# 	url = https://github.com/nono/jquery.vim.git

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ See [Bundles](https://github.com/brentlintner/vim-settings/tree/master/.vim/bund
 ## Installation
 
 ```bash
- cd ~/
- git clone git@github.com:brentlintner/vim-settings.git
- ln -s vim-settings/.vimrc
- ln -s vim-settings/.vim
- cd vim-settings
+ # clone the repo into a local directory of your choice (e.g. ~/Projects on my system)
+ cd [your_projects_folder]
+ git clone git://github.com/fourq/vim-settings.git
+ ln -s [your_projects_folder]/vim-settings/.vimrc
+ ln -s [your_projects_folder]/vim-settings/.vim
+ cd [your_projects_folder]/vim-settings
  ./configure
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,23 @@ See [Bundles](https://github.com/brentlintner/vim-settings/tree/master/.vim/bund
 ## Installation
 
 ```bash
- # clone the repo into a local directory of your choice (e.g. ~/Projects on my system)
- cd [your_projects_folder]
+ # clone the repo into a local directory of your choice (~ used in this example)
+ cd ~
  git clone git://github.com/fourq/vim-settings.git
- ln -s [your_projects_folder]/vim-settings/.vimrc
- ln -s [your_projects_folder]/vim-settings/.vim
- cd [your_projects_folder]/vim-settings
+ ln -s vim-settings/.vimrc
+ ln -s vim-settings/.vim
+ cd vim-settings
  ./configure
+```
+
+## Submodules
+
+This setup uses several git repositories as submodules.  The configure script sets up the submodules for you initially but you might need/want to pull the latest versions of each submodule at some point.  To pull them all at once use the command below.
+
+```bash
+ # cd to install directory (~/vim-settings for this example)
+ cd ~/vim-settings
+ git submodule foreach git pull
 ```
 
 ## Common Commands

--- a/configure
+++ b/configure
@@ -3,3 +3,6 @@ git submodule update --init
 
 # For JSHint/CoffeeScript Plugins
 npm install -g jshint coffee-script coffeelint
+
+# update the git submodule
+git submodule update

--- a/configure
+++ b/configure
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+
+# init the submodules
 git submodule update --init
 
 # For JSHint/CoffeeScript Plugins


### PR DESCRIPTION
Changed the URLs in the .gitmodules folder to use https links to allow public pulling/update of the git submodules for people who don't have an SSH key setup in their system (like me apparently, swear I had mine setup).  Added a line to the config script to update the submodules after the init and npm step.  Readme updated with info about pulling all submodules at once (git submodule foreach git pull).

Oh, p.s. I got vim working on my dev machine tonight finally heh.  Thanks for the awesome setup.
